### PR TITLE
Added a new role and metadata key to decide when to whitelist ips.

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -9,3 +9,5 @@ rake (version 0.8.6+)
 albacore (version 0.2.2)
 fileutils
 rubyzip (version 0.9.8)
+
+Note: ImageMagick-6.7.9-9 version might be required for fileutils to work correctly.

--- a/src/Rackspace.Cloud.Server.Agent.DiffieHellman/Properties/AssemblyInfo.cs
+++ b/src/Rackspace.Cloud.Server.Agent.DiffieHellman/Properties/AssemblyInfo.cs
@@ -1,7 +1,9 @@
 using System.Reflection;
 using System.Runtime.InteropServices;
+
 [assembly: AssemblyDescription("C#.NET Agent for Windows Virtual Machines")]
 [assembly: AssemblyCompany("Rackspace Cloud")]
 [assembly: AssemblyProduct("Rackspace Cloud Server Agent")]
 [assembly: AssemblyCopyright("Copyright (c) 2009 2010 2011, Rackspace Cloud.  All Rights Reserved")]
-[assembly: AssemblyVersion("1.3.0.1")]
+[assembly: AssemblyVersion("1.3.0.2")]
+

--- a/src/Rackspace.Cloud.Server.Agent.Service/Properties/AssemblyInfo.cs
+++ b/src/Rackspace.Cloud.Server.Agent.Service/Properties/AssemblyInfo.cs
@@ -1,7 +1,9 @@
 using System.Reflection;
 using System.Runtime.InteropServices;
+
 [assembly: AssemblyDescription("C#.NET Agent for Windows Virtual Machines")]
 [assembly: AssemblyCompany("Rackspace Cloud")]
 [assembly: AssemblyProduct("Rackspace Cloud Server Agent")]
 [assembly: AssemblyCopyright("Copyright (c) 2009 2010 2011, Rackspace Cloud.  All Rights Reserved")]
-[assembly: AssemblyVersion("1.3.0.1")]
+[assembly: AssemblyVersion("1.3.0.2")]
+

--- a/src/Rackspace.Cloud.Server.Agent.Service/app.config
+++ b/src/Rackspace.Cloud.Server.Agent.Service/app.config
@@ -10,9 +10,10 @@
 		<add key="AgentVersionUpdatesPath" value="C:\Program Files\Rackspace\Cloud Servers\Updates\"/>
     <add key="IpcUriHost" value="RackspaceAgentUpdaterService"/>
     <add key="IpcUriName" value="RackspaceAgentUpdater"/>
+    <add key="FirewallMetadataKey" value="build_config"/>
     <!-- | separated values -->
-    <add key="FirewallRoleNames" value="rax_managed|rack_connect"/>
-	</appSettings>
+    <add key="FirewallRoleNames" value="rax_managed|rack_connect|rax_build_config"/>
+  </appSettings>
 	<log4net>
 		<appender name="FileAppender" type="log4net.Appender.RollingFileAppender">
 			<file value="Agentlog.txt"/>

--- a/src/Rackspace.Cloud.Server.Agent.Specs/JsonSpec.cs
+++ b/src/Rackspace.Cloud.Server.Agent.Specs/JsonSpec.cs
@@ -42,6 +42,13 @@ namespace Rackspace.Cloud.Server.Agent.Specs {
         }
 
         [Test]
+        public void when_valid_metadata_should_return_dictionary()
+        {
+            var userMetadata = new Json<Dictionary<string, string>>().Deserialize("{ \"whatever\": \"test\",\"test2\":\"whatever\"}");
+            Assert.IsTrue(userMetadata.Count() == 2);
+        }
+
+        [Test]
         [ExpectedException(typeof(UnsuccessfulCommandExecutionException), ExpectedMessage = "Problem deserializing the following json: '{'")]
         public void should_throw_exception_with_curly_brace()
         {

--- a/src/Rackspace.Cloud.Server.Agent.Specs/Properties/AssemblyInfo.cs
+++ b/src/Rackspace.Cloud.Server.Agent.Specs/Properties/AssemblyInfo.cs
@@ -1,7 +1,9 @@
 using System.Reflection;
 using System.Runtime.InteropServices;
+
 [assembly: AssemblyDescription("C#.NET Agent for Windows Virtual Machines")]
 [assembly: AssemblyCompany("Rackspace Cloud")]
 [assembly: AssemblyProduct("Rackspace Cloud Server Agent")]
 [assembly: AssemblyCopyright("Copyright (c) 2009 2010 2011, Rackspace Cloud.  All Rights Reserved")]
-[assembly: AssemblyVersion("1.3.0.1")]
+[assembly: AssemblyVersion("1.3.0.2")]
+

--- a/src/Rackspace.Cloud.Server.Agent.Specs/ResetNetworkSpec.cs
+++ b/src/Rackspace.Cloud.Server.Agent.Specs/ResetNetworkSpec.cs
@@ -13,6 +13,7 @@ namespace Rackspace.Cloud.Server.Agent.Specs {
     public class ResetNetworkSpec {
         private ResetNetwork command;
         private IXenNetworkInformation xenNetworkInformation;
+        private IXenUserMetadata xenUserMetadata;
         private ISetNetworkInterface setNetworkInterface;
         private Network network;
         private ExecutableResult result;
@@ -22,13 +23,17 @@ namespace Rackspace.Cloud.Server.Agent.Specs {
         private ISetProviderData setProviderData;
         private IXenProviderDataInformation xenProviderDataInformation;
         private ProviderData providerData;
+        private List<string> userMetadata;
         private ISetHostnameAction setHostname;
         private IXenStore _xenStore;
         private const string hostname = "abc";
+        private static readonly List<string> vmKeys = new List<string>() { "user-metadata" };
+        private static readonly List<string> metadata = new List<string>() { "test" };
 
         [SetUp]
         public void Setup() {
             xenNetworkInformation = MockRepository.GenerateMock<IXenNetworkInformation>();
+            xenUserMetadata = MockRepository.GenerateMock<IXenUserMetadata>();
             setNetworkInterface = MockRepository.GenerateMock<ISetNetworkInterface>();
             setNetworkRoutes = MockRepository.GenerateMock<ISetNetworkRoutes>();
 
@@ -43,21 +48,25 @@ namespace Rackspace.Cloud.Server.Agent.Specs {
             network.Interfaces.Add("fakemac", networkInterface);
 
             providerData = new ProviderData();
+            userMetadata = new List<string>();
 
-            command = new ResetNetwork(setNetworkInterface, xenNetworkInformation, setNetworkRoutes, setProviderData, xenProviderDataInformation, setHostname, _xenStore);
+            command = new ResetNetwork(setNetworkInterface, xenNetworkInformation, setNetworkRoutes, setProviderData, xenProviderDataInformation, setHostname, _xenStore, xenUserMetadata);
         }
 
         [Test]
         public void should_set_interface_from_interfaceconfigiuration() {
             xenNetworkInformation.Stub(x => x.Get()).Return(network);
+            xenUserMetadata.Stub(x => x.GetKeys()).Return(userMetadata);
             xenProviderDataInformation.Stub(x => x.Get()).Return(providerData);
             _xenStore.Stub(x => x.ReadVmData("hostname")).Return(hostname);
+            _xenStore.Stub(x => x.Read("vm-data")).Return(vmKeys);
+            _xenStore.Stub(x => x.Read("vm-data/user-metadata")).Return(metadata);
 
             result = command.Execute(null);
 
             setNetworkInterface.AssertWasCalled(x => x.Execute(new List<NetworkInterface> { networkInterface }));
             setNetworkRoutes.AssertWasCalled(x => x.Execute(network));
-            setProviderData.AssertWasCalled(x => x.Execute(providerData));
+            setProviderData.AssertWasCalled(x => x.Execute(providerData, userMetadata));
             setHostname.AssertWasCalled(x => x.SetHostname(hostname));
         }
 

--- a/src/Rackspace.Cloud.Server.Agent.Specs/app.config
+++ b/src/Rackspace.Cloud.Server.Agent.Specs/app.config
@@ -2,7 +2,8 @@
 <configuration>
 	<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0"/></startup>
   <appSettings>
+    <add key="FirewallMetadataKey" value="build_config"/>
     <!-- | separated values -->
-    <add key="FirewallRoleNames" value="rax_managed|rack_connect"/>
+    <add key="FirewallRoleNames" value="rax_managed|rack_connect|rax_build_config"/>
   </appSettings>
 </configuration>

--- a/src/Rackspace.Cloud.Server.Agent.UpdaterService/Properties/AssemblyInfo.cs
+++ b/src/Rackspace.Cloud.Server.Agent.UpdaterService/Properties/AssemblyInfo.cs
@@ -1,7 +1,9 @@
 using System.Reflection;
 using System.Runtime.InteropServices;
+
 [assembly: AssemblyDescription("C#.NET Agent for Windows Virtual Machines")]
 [assembly: AssemblyCompany("Rackspace Cloud")]
 [assembly: AssemblyProduct("Rackspace Cloud Server Agent")]
 [assembly: AssemblyCopyright("Copyright (c) 2009 2010 2011, Rackspace Cloud.  All Rights Reserved")]
-[assembly: AssemblyVersion("1.3.0.1")]
+[assembly: AssemblyVersion("1.3.0.2")]
+

--- a/src/Rackspace.Cloud.Server.Agent/Commands/ResetNetwork.cs
+++ b/src/Rackspace.Cloud.Server.Agent/Commands/ResetNetwork.cs
@@ -28,6 +28,7 @@ namespace Rackspace.Cloud.Server.Agent.Commands
     {
         private readonly ISetNetworkInterface _setNetworkInterface;
         private readonly IXenNetworkInformation _xenNetworkInformation;
+        private readonly IXenUserMetadata _xenUserMetadata;
         private readonly ISetNetworkRoutes _setNetworkRoutes;
 
         private readonly ISetProviderData _setProviderData;
@@ -36,7 +37,7 @@ namespace Rackspace.Cloud.Server.Agent.Commands
         private readonly IXenStore _xenStore;
 
         public ResetNetwork(ISetNetworkInterface setNetworkInterface, IXenNetworkInformation xenNetworkInformation, ISetNetworkRoutes setNetworkRoutes, 
-            ISetProviderData setProviderData, IXenProviderDataInformation xenProviderDataInformation, ISetHostnameAction setHostname, IXenStore xenStore)
+            ISetProviderData setProviderData, IXenProviderDataInformation xenProviderDataInformation, ISetHostnameAction setHostname, IXenStore xenStore, IXenUserMetadata xenUserMetadata)
         {
             _setNetworkInterface = setNetworkInterface;
             _xenNetworkInformation = xenNetworkInformation;
@@ -46,6 +47,7 @@ namespace Rackspace.Cloud.Server.Agent.Commands
             _xenProviderDataInformation = xenProviderDataInformation;
             _setHostname = setHostname;
             _xenStore = xenStore;
+            _xenUserMetadata = xenUserMetadata;
         }
 
         public ExecutableResult Execute(string keyValue)
@@ -56,7 +58,8 @@ namespace Rackspace.Cloud.Server.Agent.Commands
             _setNetworkRoutes.Execute(network);
 
             var providerData = _xenProviderDataInformation.Get();
-            _setProviderData.Execute(providerData);
+            var userMetadata = _xenUserMetadata.GetKeys();
+            _setProviderData.Execute(providerData, userMetadata);
 
             var hostname = _xenStore.ReadVmData("hostname");
             var hostnameResult = _setHostname.SetHostname(hostname);

--- a/src/Rackspace.Cloud.Server.Agent/Constants.cs
+++ b/src/Rackspace.Cloud.Server.Agent/Constants.cs
@@ -26,7 +26,7 @@ namespace Rackspace.Cloud.Server.Agent {
         public const string RackspaceRegKey = @"SOFTWARE\Rackspace";
         public const string CloudAutomationSysPrepRegKey = "cloud-automation";
         public const string CloudAutomationKMSActivateRegKey = "cloud-automation-run";
-
+        
         public const string CloudAutomationCmdPath = @"c:\cloud-automation\bootstrap.cmd";
         public const string CloudAutomationBatPath = @"c:\cloud-automation\bootstrap.bat";
 
@@ -34,6 +34,7 @@ namespace Rackspace.Cloud.Server.Agent {
         public const string WritableDataHostBase = "data/host";
         public const string WritableDataGuestBase = "data/guest";
         public const string NetworkingBase = "networking";
+        public const string MetadataBase = "user-metadata";
         public const string ProviderDataBase = "provider_data";
         public const string Provider = "provider";
         public const string Roles = "roles";

--- a/src/Rackspace.Cloud.Server.Agent/IoC.cs
+++ b/src/Rackspace.Cloud.Server.Agent/IoC.cs
@@ -42,6 +42,7 @@ namespace Rackspace.Cloud.Server.Agent {
             StructureMapConfiguration.BuildInstancesOf<ISetPassword>().TheDefaultIsConcreteType<SetPassword>();
             StructureMapConfiguration.BuildInstancesOf<IWmiMacNetworkNameGetter>().TheDefaultIsConcreteType<WmiMacNetworkNameGetter>();
             StructureMapConfiguration.BuildInstancesOf<IXenNetworkInformation>().TheDefaultIsConcreteType<XenNetworkInformation>();
+            StructureMapConfiguration.BuildInstancesOf<IXenUserMetadata>().TheDefaultIsConcreteType<XenUserMetadata>();
             StructureMapConfiguration.BuildInstancesOf<IAgentUpdateMessageSender>().TheDefaultIsConcreteType<AgentUpdateMessageSender>();
             StructureMapConfiguration.BuildInstancesOf<IDiffieHellmanPrerequisitesChecker>().TheDefaultIsConcreteType<DiffieHellmanPrerequisitesChecker>();
             StructureMapConfiguration.BuildInstancesOf<IOperatingSystemChecker>().TheDefaultIsConcreteType<OperatingSystemChecker>();

--- a/src/Rackspace.Cloud.Server.Agent/Properties/AssemblyInfo.cs
+++ b/src/Rackspace.Cloud.Server.Agent/Properties/AssemblyInfo.cs
@@ -1,7 +1,9 @@
 using System.Reflection;
 using System.Runtime.InteropServices;
+
 [assembly: AssemblyDescription("C#.NET Agent for Windows Virtual Machines")]
 [assembly: AssemblyCompany("Rackspace Cloud")]
 [assembly: AssemblyProduct("Rackspace Cloud Server Agent")]
 [assembly: AssemblyCopyright("Copyright (c) 2009 2010 2011, Rackspace Cloud.  All Rights Reserved")]
-[assembly: AssemblyVersion("1.3.0.1")]
+[assembly: AssemblyVersion("1.3.0.2")]
+

--- a/src/Rackspace.Cloud.Server.Agent/Rackspace.Cloud.Server.Agent.csproj
+++ b/src/Rackspace.Cloud.Server.Agent/Rackspace.Cloud.Server.Agent.csproj
@@ -119,6 +119,7 @@
     <Compile Include="Configuration\ProviderData.cs" />
     <Compile Include="Configuration\Ipv4Tuple.cs" />
     <Compile Include="Configuration\Ipv6Tuple.cs" />
+    <Compile Include="XenUserMetadata.cs" />
     <Compile Include="PreAndPostCommandAttribute.cs" />
     <Compile Include="XenStoreWmi.cs" />
     <Compile Include="Netsh\NetshFirewallRuleNameAvailable.cs" />

--- a/src/Rackspace.Cloud.Server.Agent/XenUserMetadata.cs
+++ b/src/Rackspace.Cloud.Server.Agent/XenUserMetadata.cs
@@ -1,0 +1,51 @@
+﻿// Copyright 2011 OpenStack LLC.
+// All Rights Reserved.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License"); you may
+//    not use this file except in compliance with the License. You may obtain
+//    a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+//    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+//    License for the specific language governing permissions and limitations
+//    under the License.
+
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Rackspace.Cloud.Server.Agent.Interfaces;
+using Rackspace.Cloud.Server.Agent.Utilities;
+using Rackspace.Cloud.Server.Common.Configuration;
+
+namespace Rackspace.Cloud.Server.Agent {
+    public interface IXenUserMetadata {
+        List<string> GetKeys();
+    }
+
+    public class XenUserMetadata : IXenUserMetadata {
+        private readonly IXenStore _xenStore;
+        private readonly string _metadataKeyLocation = Constants.Combine(Constants.ReadOnlyDataConfigBase, Constants.MetadataBase);
+        public XenUserMetadata(IXenStore xenstore)
+        {
+            _xenStore = xenstore;
+        }
+
+        public List<string> GetKeys()
+        {
+            var vmDataItems = _xenStore.Read(Constants.ReadOnlyDataConfigBase);
+            if (vmDataItems != null && vmDataItems.Contains(Constants.MetadataBase))
+            {
+                var metadataItems =  _xenStore.Read(_metadataKeyLocation);
+                if (metadataItems != null)
+                {
+                    return metadataItems.ToList();
+                }
+            }
+            return new List<string>();
+        }
+    }
+}

--- a/src/Rackspace.Cloud.Server.Common/Configuration/SvcConfiguration.cs
+++ b/src/Rackspace.Cloud.Server.Common/Configuration/SvcConfiguration.cs
@@ -57,6 +57,11 @@ namespace Rackspace.Cloud.Server.Common.Configuration {
             get { return ConfigurationManager.AppSettings["FirewallRoleNames"]; }
         }
 
+        public static string FirewallMetadataKey
+        {
+            get { return ConfigurationManager.AppSettings["FirewallMetadataKey"]; }
+        }
+
         public static string PreHookPath(string command)
         {
             return ConfigurationManager.AppSettings[string.Format("{0}_pre", command.ToLower())];

--- a/src/Rackspace.Cloud.Server.Common/Properties/AssemblyInfo.cs
+++ b/src/Rackspace.Cloud.Server.Common/Properties/AssemblyInfo.cs
@@ -1,7 +1,9 @@
 using System.Reflection;
 using System.Runtime.InteropServices;
+
 [assembly: AssemblyDescription("C#.NET Agent for Windows Virtual Machines")]
 [assembly: AssemblyCompany("Rackspace Cloud")]
 [assembly: AssemblyProduct("Rackspace Cloud Server Agent")]
 [assembly: AssemblyCopyright("Copyright (c) 2009 2010 2011, Rackspace Cloud.  All Rights Reserved")]
-[assembly: AssemblyVersion("1.3.0.1")]
+[assembly: AssemblyVersion("1.3.0.2")]
+

--- a/src/Rackspace.Cloud.Server.DiffieHellman.Specs/Properties/AssemblyInfo.cs
+++ b/src/Rackspace.Cloud.Server.DiffieHellman.Specs/Properties/AssemblyInfo.cs
@@ -1,7 +1,9 @@
 using System.Reflection;
 using System.Runtime.InteropServices;
+
 [assembly: AssemblyDescription("C#.NET Agent for Windows Virtual Machines")]
 [assembly: AssemblyCompany("Rackspace Cloud")]
 [assembly: AssemblyProduct("Rackspace Cloud Server Agent")]
 [assembly: AssemblyCopyright("Copyright (c) 2009 2010 2011, Rackspace Cloud.  All Rights Reserved")]
-[assembly: AssemblyVersion("1.3.0.1")]
+[assembly: AssemblyVersion("1.3.0.2")]
+


### PR DESCRIPTION
Request from Raj Patel from the servermill team.

- **Current Behavior:** Windows nova-agent updates firewalls and white lists the list ip address provided in xenstore only if the customer has rax_managed or rack_connect role.

- **New Behavior:** Windows nova-agent updates firewalls and white lists the list ip address provided in xenstore only if the customer has rax_managed or rack connect or rax_build_options role or server metadata contains build_options

### Solution:
- Added a new class to handle Metadata and implemented GetMetadataKeys which uses capabilities from the xen client to list the path keys and comes up with a list of metadata keys, on which we base of to decide if we should show whitelist the ips. 
- Added unit tests to validate the changes 