### PR TITLE
Increasing build number

### DIFF
--- a/Properties.rb
+++ b/Properties.rb
@@ -6,7 +6,7 @@ COPYRIGHT = "Copyright (c) 2009 2010 2011, Rackspace Cloud.  All Rights Reserved
 COMPANY = "Rackspace Cloud"
 DESCRIPTION = "C#.NET Agent for Windows Virtual Machines"
 CLR_VERSION = 'v3.5'
-RELEASE_BUILD_NUMBER = "1.3.0.1"
+RELEASE_BUILD_NUMBER = "1.3.0.2"
 
 #Paths
 SLN_FILE = File.join(ABSOLUTE_PATH,'src','WindowsConfigurationAgent.sln')


### PR DESCRIPTION
I think this got overridden when I rebased, all assembly info seems to be up to date with the new version, so this is the only change needed.