### PR TITLE
Fix WMI detection and reset-network

### DIFF
--- a/Properties.rb
+++ b/Properties.rb
@@ -6,7 +6,7 @@ COPYRIGHT = "Copyright (c) 2009 2010 2011, Rackspace Cloud.  All Rights Reserved
 COMPANY = "Rackspace Cloud"
 DESCRIPTION = "C#.NET Agent for Windows Virtual Machines"
 CLR_VERSION = 'v3.5'
-RELEASE_BUILD_NUMBER = "1.3.0.2"
+RELEASE_BUILD_NUMBER = "1.3.0.3"
 
 #Paths
 SLN_FILE = File.join(ABSOLUTE_PATH,'src','WindowsConfigurationAgent.sln')

--- a/src/Rackspace.Cloud.Server.Agent.DiffieHellman/Properties/AssemblyInfo.cs
+++ b/src/Rackspace.Cloud.Server.Agent.DiffieHellman/Properties/AssemblyInfo.cs
@@ -1,9 +1,8 @@
 using System.Reflection;
 using System.Runtime.InteropServices;
-
 [assembly: AssemblyDescription("C#.NET Agent for Windows Virtual Machines")]
 [assembly: AssemblyCompany("Rackspace Cloud")]
 [assembly: AssemblyProduct("Rackspace Cloud Server Agent")]
 [assembly: AssemblyCopyright("Copyright (c) 2009 2010 2011, Rackspace Cloud.  All Rights Reserved")]
-[assembly: AssemblyVersion("1.3.0.2")]
+[assembly: AssemblyVersion("1.3.0.3")]
 

--- a/src/Rackspace.Cloud.Server.Agent.Service/Properties/AssemblyInfo.cs
+++ b/src/Rackspace.Cloud.Server.Agent.Service/Properties/AssemblyInfo.cs
@@ -1,9 +1,8 @@
 using System.Reflection;
 using System.Runtime.InteropServices;
-
 [assembly: AssemblyDescription("C#.NET Agent for Windows Virtual Machines")]
 [assembly: AssemblyCompany("Rackspace Cloud")]
 [assembly: AssemblyProduct("Rackspace Cloud Server Agent")]
 [assembly: AssemblyCopyright("Copyright (c) 2009 2010 2011, Rackspace Cloud.  All Rights Reserved")]
-[assembly: AssemblyVersion("1.3.0.2")]
+[assembly: AssemblyVersion("1.3.0.3")]
 

--- a/src/Rackspace.Cloud.Server.Agent.Specs/Properties/AssemblyInfo.cs
+++ b/src/Rackspace.Cloud.Server.Agent.Specs/Properties/AssemblyInfo.cs
@@ -1,9 +1,8 @@
 using System.Reflection;
 using System.Runtime.InteropServices;
-
 [assembly: AssemblyDescription("C#.NET Agent for Windows Virtual Machines")]
 [assembly: AssemblyCompany("Rackspace Cloud")]
 [assembly: AssemblyProduct("Rackspace Cloud Server Agent")]
 [assembly: AssemblyCopyright("Copyright (c) 2009 2010 2011, Rackspace Cloud.  All Rights Reserved")]
-[assembly: AssemblyVersion("1.3.0.2")]
+[assembly: AssemblyVersion("1.3.0.3")]
 

--- a/src/Rackspace.Cloud.Server.Agent.Specs/SetNetworkInterfaceSpec.cs
+++ b/src/Rackspace.Cloud.Server.Agent.Specs/SetNetworkInterfaceSpec.cs
@@ -107,7 +107,7 @@ namespace Rackspace.Cloud.Server.Agent.Specs {
             ExecutableProcessQueue.AssertWasCalled(
                 x =>
                 x.Enqueue("netsh",
-                          "interface ipv6 add route prefix=::/0 interface=\"Lan1\" nexthop=fe80::def publish=Yes"));
+                          "interface ipv6 add route prefix=::/0 interface=\"Lan1\" nexthop=fe80::def publish=Yes", new[] { "0", "1" }));
         }
 
         [Test]
@@ -135,7 +135,7 @@ namespace Rackspace.Cloud.Server.Agent.Specs {
             ExecutableProcessQueue.AssertWasCalled(
                 x =>
                 x.Enqueue("netsh",
-                          "interface ipv6 add route prefix=::/0 interface=\"Lan1\" nexthop=fe80::def publish=Yes"));
+                          "interface ipv6 add route prefix=::/0 interface=\"Lan1\" nexthop=fe80::def publish=Yes", new[] { "0", "1" }));
         }
 
   

--- a/src/Rackspace.Cloud.Server.Agent.UpdaterService/Properties/AssemblyInfo.cs
+++ b/src/Rackspace.Cloud.Server.Agent.UpdaterService/Properties/AssemblyInfo.cs
@@ -1,9 +1,8 @@
 using System.Reflection;
 using System.Runtime.InteropServices;
-
 [assembly: AssemblyDescription("C#.NET Agent for Windows Virtual Machines")]
 [assembly: AssemblyCompany("Rackspace Cloud")]
 [assembly: AssemblyProduct("Rackspace Cloud Server Agent")]
 [assembly: AssemblyCopyright("Copyright (c) 2009 2010 2011, Rackspace Cloud.  All Rights Reserved")]
-[assembly: AssemblyVersion("1.3.0.2")]
+[assembly: AssemblyVersion("1.3.0.3")]
 

--- a/src/Rackspace.Cloud.Server.Agent/IoC.cs
+++ b/src/Rackspace.Cloud.Server.Agent/IoC.cs
@@ -13,6 +13,7 @@
 //    License for the specific language governing permissions and limitations
 //    under the License.
 
+using System.IO;
 using Rackspace.Cloud.Server.Agent.Actions;
 using Rackspace.Cloud.Server.Agent.Commands;
 using Rackspace.Cloud.Server.Agent.Interfaces;
@@ -23,7 +24,6 @@ using Rackspace.Cloud.Server.Common.Logging;
 using Rackspace.Cloud.Server.DiffieHellman;
 using StructureMap;
 using StructureMap.Configuration.DSL;
-using WinRegistry = Microsoft.Win32.Registry;
 
 namespace Rackspace.Cloud.Server.Agent {
     public class IoC {
@@ -33,10 +33,12 @@ namespace Rackspace.Cloud.Server.Agent {
             StructureMapConfiguration.BuildInstancesOf<IExecutableProcess>().TheDefaultIsConcreteType<ExecutableProcess>();
             StructureMapConfiguration.BuildInstancesOf<ILogger>().TheDefaultIsConcreteType<Logger>();
             StructureMapConfiguration.BuildInstancesOf<IExecutableProcessQueue>().TheDefaultIsConcreteType<ExecutableProcessQueue>();
-            if (IsWmiTools())
+
+            if (XenStoreWmi.IsWmiEnabled())
                 StructureMapConfiguration.BuildInstancesOf<IXenStore>().TheDefaultIsConcreteType<XenStoreWmi>();
             else
                 StructureMapConfiguration.BuildInstancesOf<IXenStore>().TheDefaultIsConcreteType<XenStore>();
+
             StructureMapConfiguration.BuildInstancesOf<IExecutableProcessCommandPatternSubsitution>().TheDefaultIsConcreteType<ExecutableProcessCommandPatternSubsitution>();
             StructureMapConfiguration.BuildInstancesOf<ISetNetworkInterface>().TheDefaultIsConcreteType<SetNetworkInterface>();
             StructureMapConfiguration.BuildInstancesOf<ISetPassword>().TheDefaultIsConcreteType<SetPassword>();
@@ -110,12 +112,5 @@ namespace Rackspace.Cloud.Server.Agent {
             StructureMapConfiguration.AddInstanceOf<IExecutableCommand>().UsingConcreteType<EnsureMinAgentUpdater>().WithName(Utilities.Commands.ensureminagentupdater.ToString());
         }
 
-        private static bool IsWmiTools()
-        {
-            var majorVersion = (int) (WinRegistry.GetValue(Constants.XenToolsRegPath, "MajorVersion", 0) ?? 0);
-            var minorVersion = (int) (WinRegistry.GetValue(Constants.XenToolsRegPath, "MinorVersion", 0) ?? 0);
-
-            return float.Parse(majorVersion + "." + minorVersion) > 6.0;
-        }
     }
 }

--- a/src/Rackspace.Cloud.Server.Agent/Properties/AssemblyInfo.cs
+++ b/src/Rackspace.Cloud.Server.Agent/Properties/AssemblyInfo.cs
@@ -1,9 +1,8 @@
 using System.Reflection;
 using System.Runtime.InteropServices;
-
 [assembly: AssemblyDescription("C#.NET Agent for Windows Virtual Machines")]
 [assembly: AssemblyCompany("Rackspace Cloud")]
 [assembly: AssemblyProduct("Rackspace Cloud Server Agent")]
 [assembly: AssemblyCopyright("Copyright (c) 2009 2010 2011, Rackspace Cloud.  All Rights Reserved")]
-[assembly: AssemblyVersion("1.3.0.2")]
+[assembly: AssemblyVersion("1.3.0.3")]
 

--- a/src/Rackspace.Cloud.Server.Agent/XenStore.cs
+++ b/src/Rackspace.Cloud.Server.Agent/XenStore.cs
@@ -25,6 +25,11 @@ namespace Rackspace.Cloud.Server.Agent
     {
         private readonly IExecutableProcess _executableProcess;
 
+        protected virtual string GetXenClientPath()
+        {
+            return Constants.XenClientPath;
+        }
+
         public XenStore(IExecutableProcess executableProcess)
         {
             _executableProcess = executableProcess;
@@ -32,7 +37,7 @@ namespace Rackspace.Cloud.Server.Agent
 
         public IEnumerable<string> Read(string key)
         {
-            return _executableProcess.Run(Constants.XenClientPath, "dir " + key).Output;
+            return _executableProcess.Run(GetXenClientPath(), "dir " + key).Output;
         }
 
         public IList<Command> GetCommands()
@@ -53,25 +58,25 @@ namespace Rackspace.Cloud.Server.Agent
 
         public string ReadKey(string key)
         {
-            var result = _executableProcess.Run(Constants.XenClientPath, "read " + Constants.Combine(Constants.WritableDataHostBase, key));
+            var result = _executableProcess.Run(GetXenClientPath(), "read " + Constants.Combine(Constants.WritableDataHostBase, key));
             return result.Output.First();
         }
 
         public string ReadVmData(string key)
         {
-            var result = _executableProcess.Run(Constants.XenClientPath, "read " + Constants.Combine(Constants.ReadOnlyDataConfigBase, key));
+            var result = _executableProcess.Run(GetXenClientPath(), "read " + Constants.Combine(Constants.ReadOnlyDataConfigBase, key));
             return result.Output.First();
         }
 
         public string ReadVmDataKey(string key)
         {
-            var result = _executableProcess.Run(Constants.XenClientPath, "read " + Constants.Combine(Constants.ReadOnlyDataConfigBase, Constants.NetworkingBase, key));
+            var result = _executableProcess.Run(GetXenClientPath(), "read " + Constants.Combine(Constants.ReadOnlyDataConfigBase, Constants.NetworkingBase, key));
             return result.Output.First();
         }
 
         public string ReadVmProviderDataKey(string key)
         {
-            var result = _executableProcess.Run(Constants.XenClientPath, "read " + Constants.Combine(Constants.ReadOnlyDataConfigBase, Constants.ProviderDataBase, key));
+            var result = _executableProcess.Run(GetXenClientPath(), "read " + Constants.Combine(Constants.ReadOnlyDataConfigBase, Constants.ProviderDataBase, key));
             if (result.ExitCode == "0" && result.Output != null && result.Output.Any())
                 return result.Output.First();
             return string.Empty;
@@ -79,12 +84,12 @@ namespace Rackspace.Cloud.Server.Agent
 
         public void Write(string key, string value)
         {
-            _executableProcess.Run(Constants.XenClientPath, "write " + Constants.Combine(Constants.WritableDataGuestBase, key) + " " + value.EscapeQuotesForXenClientWrite());
+            _executableProcess.Run(GetXenClientPath(), "write " + Constants.Combine(Constants.WritableDataGuestBase, key) + " " + value.EscapeQuotesForXenClientWrite());
         }
 
         public void Remove(string key)
         {
-            _executableProcess.Run(Constants.XenClientPath, "remove " + Constants.Combine(Constants.WritableDataHostBase, key));
+            _executableProcess.Run(GetXenClientPath(), "remove " + Constants.Combine(Constants.WritableDataHostBase, key));
         }
     }
 }

--- a/src/Rackspace.Cloud.Server.Common/Properties/AssemblyInfo.cs
+++ b/src/Rackspace.Cloud.Server.Common/Properties/AssemblyInfo.cs
@@ -1,9 +1,8 @@
 using System.Reflection;
 using System.Runtime.InteropServices;
-
 [assembly: AssemblyDescription("C#.NET Agent for Windows Virtual Machines")]
 [assembly: AssemblyCompany("Rackspace Cloud")]
 [assembly: AssemblyProduct("Rackspace Cloud Server Agent")]
 [assembly: AssemblyCopyright("Copyright (c) 2009 2010 2011, Rackspace Cloud.  All Rights Reserved")]
-[assembly: AssemblyVersion("1.3.0.2")]
+[assembly: AssemblyVersion("1.3.0.3")]
 

--- a/src/Rackspace.Cloud.Server.DiffieHellman.Specs/Properties/AssemblyInfo.cs
+++ b/src/Rackspace.Cloud.Server.DiffieHellman.Specs/Properties/AssemblyInfo.cs
@@ -1,9 +1,8 @@
 using System.Reflection;
 using System.Runtime.InteropServices;
-
 [assembly: AssemblyDescription("C#.NET Agent for Windows Virtual Machines")]
 [assembly: AssemblyCompany("Rackspace Cloud")]
 [assembly: AssemblyProduct("Rackspace Cloud Server Agent")]
 [assembly: AssemblyCopyright("Copyright (c) 2009 2010 2011, Rackspace Cloud.  All Rights Reserved")]
-[assembly: AssemblyVersion("1.3.0.2")]
+[assembly: AssemblyVersion("1.3.0.3")]
 


### PR DESCRIPTION
- Fixed WMI detection for 64 bit systems that run this code in 32 bit mode by removing the registry check and replacing it with a wmi check directly.
- Fixed a Null Reference exception in the WMI code
- Fixed an issue with Reset-Network so that now it can reset network properly even if the ip addresses on a box are swapped by clearing all known mac address ip information first then setting each nic.