### PR TITLE
Added Xen Tools Installer logic for custom packages.

### DIFF
--- a/Properties.rb
+++ b/Properties.rb
@@ -6,7 +6,7 @@ COPYRIGHT = "Copyright (c) 2009 2010 2011, Rackspace Cloud.  All Rights Reserved
 COMPANY = "Rackspace Cloud"
 DESCRIPTION = "C#.NET Agent for Windows Virtual Machines"
 CLR_VERSION = 'v3.5'
-RELEASE_BUILD_NUMBER = "1.3.0.3"
+RELEASE_BUILD_NUMBER = "1.3.1.0"
 
 #Paths
 SLN_FILE = File.join(ABSOLUTE_PATH,'src','WindowsConfigurationAgent.sln')

--- a/src/Rackspace.Cloud.Server.Agent.DiffieHellman/Properties/AssemblyInfo.cs
+++ b/src/Rackspace.Cloud.Server.Agent.DiffieHellman/Properties/AssemblyInfo.cs
@@ -4,5 +4,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCompany("Rackspace Cloud")]
 [assembly: AssemblyProduct("Rackspace Cloud Server Agent")]
 [assembly: AssemblyCopyright("Copyright (c) 2009 2010 2011, Rackspace Cloud.  All Rights Reserved")]
-[assembly: AssemblyVersion("1.3.0.3")]
+[assembly: AssemblyVersion("1.3.1.0")]
 

--- a/src/Rackspace.Cloud.Server.Agent.Service/Properties/AssemblyInfo.cs
+++ b/src/Rackspace.Cloud.Server.Agent.Service/Properties/AssemblyInfo.cs
@@ -4,5 +4,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCompany("Rackspace Cloud")]
 [assembly: AssemblyProduct("Rackspace Cloud Server Agent")]
 [assembly: AssemblyCopyright("Copyright (c) 2009 2010 2011, Rackspace Cloud.  All Rights Reserved")]
-[assembly: AssemblyVersion("1.3.0.3")]
+[assembly: AssemblyVersion("1.3.1.0")]
 

--- a/src/Rackspace.Cloud.Server.Agent.Service/ServerClass.cs
+++ b/src/Rackspace.Cloud.Server.Agent.Service/ServerClass.cs
@@ -51,6 +51,7 @@ namespace Rackspace.Cloud.Server.Agent.Service {
             StructureMapConfiguration.BuildInstancesOf<ITimer>().TheDefaultIs(Registry.Object(_timer));
             IoC.Register();
 
+            RunXenToolsUpgradeChecks();
             RunCloudAutomation();
             CheckAgentUpdater();
 
@@ -102,6 +103,12 @@ namespace Rackspace.Cloud.Server.Agent.Service {
         {
             var cloudAutomationActions = ObjectFactory.GetInstance<ICloudAutomationActions>();
             cloudAutomationActions.RunPostRebootCloudAutomationScripts();
+        }
+
+        private void RunXenToolsUpgradeChecks()
+        {
+            var xenToolsUpdateActions = ObjectFactory.GetInstance<IXenToolsUpdateActions>();
+            xenToolsUpdateActions.ProcessXenToolsPostUpgradeActions();
         }
     }
 }

--- a/src/Rackspace.Cloud.Server.Agent.Specs/Properties/AssemblyInfo.cs
+++ b/src/Rackspace.Cloud.Server.Agent.Specs/Properties/AssemblyInfo.cs
@@ -4,5 +4,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCompany("Rackspace Cloud")]
 [assembly: AssemblyProduct("Rackspace Cloud Server Agent")]
 [assembly: AssemblyCopyright("Copyright (c) 2009 2010 2011, Rackspace Cloud.  All Rights Reserved")]
-[assembly: AssemblyVersion("1.3.0.3")]
+[assembly: AssemblyVersion("1.3.1.0")]
 

--- a/src/Rackspace.Cloud.Server.Agent.Specs/XentoolsUpdateSpec.cs
+++ b/src/Rackspace.Cloud.Server.Agent.Specs/XentoolsUpdateSpec.cs
@@ -25,6 +25,7 @@ namespace Rackspace.Cloud.Server.Agent.Specs
         private IServiceRestarter _serviceRestarter;
         private ILogger _logger;
         private MockRepository _mockRepo;
+        private IXenToolsUpdateSubActions _xenToolsUpdateSubActions;
 
         [SetUp]
         public void Setup()
@@ -40,12 +41,13 @@ namespace Rackspace.Cloud.Server.Agent.Specs
             _connectionChecker = MockRepository.GenerateMock<IConnectionChecker>();
             _sleeper = MockRepository.GenerateMock<ISleeper>();
             _logger = MockRepository.GenerateMock<ILogger>();
+            _xenToolsUpdateSubActions = MockRepository.GenerateMock<IXenToolsUpdateSubActions>();
             _serviceRestarter = _mockRepo.StrictMock<IServiceRestarter>();
             _agentUpdateMessageHandler = new AgentUpdateMessageHandler();
 
             _logger.Stub(x => x.Log(Arg<string>.Is.Anything));
 
-            _xentoolsUpdate = new XentoolsUpdate(_sleeper, _downloader, _checksumValidator, _unzipper, _installer, _finalizer, _serviceRestarter, _connectionChecker, _agentUpdateMessageHandler, _logger);
+            _xentoolsUpdate = new XentoolsUpdate(_sleeper, _downloader, _checksumValidator, _unzipper, _installer, _finalizer, _serviceRestarter, _connectionChecker, _agentUpdateMessageHandler, _logger, _xenToolsUpdateSubActions);
 
         }
 

--- a/src/Rackspace.Cloud.Server.Agent.UpdaterService/Properties/AssemblyInfo.cs
+++ b/src/Rackspace.Cloud.Server.Agent.UpdaterService/Properties/AssemblyInfo.cs
@@ -4,5 +4,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCompany("Rackspace Cloud")]
 [assembly: AssemblyProduct("Rackspace Cloud Server Agent")]
 [assembly: AssemblyCopyright("Copyright (c) 2009 2010 2011, Rackspace Cloud.  All Rights Reserved")]
-[assembly: AssemblyVersion("1.3.0.3")]
+[assembly: AssemblyVersion("1.3.1.0")]
 

--- a/src/Rackspace.Cloud.Server.Agent/Actions/XenToolsUpdateActions.cs
+++ b/src/Rackspace.Cloud.Server.Agent/Actions/XenToolsUpdateActions.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Rackspace.Cloud.Server.Agent.Configuration;
+using Rackspace.Cloud.Server.Agent.Interfaces;
+using Rackspace.Cloud.Server.Agent.Utilities;
+using Rackspace.Cloud.Server.Common.Logging;
+
+namespace Rackspace.Cloud.Server.Agent.Actions
+{
+    public interface IXenToolsUpdateActions
+    {
+        void ProcessXenToolsPostUpgradeActions();
+    }
+
+    public class XenToolsUpdateActions : IXenToolsUpdateActions
+    {
+        private readonly ILogger _logger;
+        private readonly IXenToolsUpdateSubActions _xenToolsUpdateSubActions;
+        private readonly ICommandFactory _factory;
+
+        public XenToolsUpdateActions(ILogger logger, IXenToolsUpdateSubActions xenToolsUpdateSubActions, ICommandFactory commandFactory)
+        {
+            _logger = logger;
+            _xenToolsUpdateSubActions = xenToolsUpdateSubActions;
+            _factory = commandFactory;
+        }
+
+
+        public void ProcessXenToolsPostUpgradeActions()
+        {
+            if (_xenToolsUpdateSubActions.IsXenToolsUpdateSignalPresent())
+            {
+                _logger.Log("Xen Tools update signal was detected");
+                if (XenStoreWmi.IsWmiEnabled())
+                {
+                    _logger.Log("Xen Store WMI Interface successfully detected, running resetnetwork");
+                    if (RunResetNetworkCommand())
+                    {
+                        _logger.Log("Reset Netowrk successfully executed");
+                        if (_xenToolsUpdateSubActions.RemoveXenToolsUpdateSignal())
+                        {
+                            _logger.Log("Xen Tools update signal successfully removed");
+                        }
+                        else
+                        {
+                            _logger.Log("Error removing Xen Tools update signal, please manually remove before reboot..");
+                            _logger.Log(Constants.RackspaceRegKey);
+                            _logger.Log(Constants.XenToolsUpdateSignalKey);
+                        }
+                    }
+                    else
+                    {
+                        _logger.Log("Error running reset-network for post Xen Tools Upgrade process, will retry at next service startup");
+                    }
+                }
+                else
+                {
+                    _logger.Log("WMI is not active yet, not processing Xen Tools Post Upgrade Command");
+                }
+            }
+            else
+            {
+                _logger.Log("Xen Tools update signal is not present");
+            }
+        }
+
+        public bool RunResetNetworkCommand()
+        {
+            var success = false;
+
+            try
+            {
+                var executableCommand = _factory.CreateCommand("resetnetwork");
+                var executableResult = executableCommand.Execute("nohostname");
+                _logger.Log(executableResult.Output.Value());
+                success = true;
+            }
+            catch (InvalidCommandException exception)
+            {
+                _logger.Log(exception.Message);
+            }
+            catch (UnsuccessfulCommandExecutionException exception)
+            {
+                var result = (ExecutableResult)exception.Data["result"];
+                var output = "";
+                var error = "";
+                if (result.Output != null && !string.IsNullOrEmpty(result.Output.Value()))
+                    output = ", Output:" + result.Output.Value();
+                if (result.Error != null && !string.IsNullOrEmpty(result.Error.Value()))
+                    error = ", Error:" + result.Error.Value();
+
+                _logger.Log(string.Format("{0}{1}{2}", exception.Message, output, error));
+
+            }
+
+            return success;
+        }
+
+    }
+}

--- a/src/Rackspace.Cloud.Server.Agent/Actions/XenToolsUpdateSubActions.cs
+++ b/src/Rackspace.Cloud.Server.Agent/Actions/XenToolsUpdateSubActions.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Win32;
+using Rackspace.Cloud.Server.Common.Logging;
+
+namespace Rackspace.Cloud.Server.Agent.Actions
+{
+    public interface IXenToolsUpdateSubActions
+    {
+        bool IsXenToolsUpdateSignalPresent();
+        bool RemoveXenToolsUpdateSignal();
+        bool WriteXenToolsUpdateSignal();
+    }
+
+    public class XenToolsUpdateSubActions : IXenToolsUpdateSubActions
+    {
+        private readonly ILogger _logger;
+
+        public XenToolsUpdateSubActions(ILogger logger)
+        {
+            _logger = logger;
+        }
+
+        public bool IsXenToolsUpdateSignalPresent()
+        {
+            using (var rk = Registry.LocalMachine.OpenSubKey(Constants.RackspaceRegKey))
+            {
+                if (rk != null)
+                {
+                    var signal = rk.GetValue(Constants.XenToolsUpdateSignalKey);
+
+                    if (signal != null)
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        public bool RemoveXenToolsUpdateSignal()
+        {
+            try
+            {
+                using (var rk = Registry.LocalMachine.OpenSubKey(Constants.RackspaceRegKey, true))
+                {
+                    if (rk != null)
+                    {
+                        rk.DeleteValue(Constants.XenToolsUpdateSignalKey);
+                    }
+                }
+
+                return true;
+            }
+            catch (Exception ex)
+            {
+                _logger.Log(ex.ToString());
+                return false;
+            }
+        }
+
+        public bool WriteXenToolsUpdateSignal()
+        {
+            try
+            {
+                using (var rsrk = Registry.LocalMachine.CreateSubKey(Constants.RackspaceRegKey))
+                {
+                    if (rsrk != null)
+                    {
+                        rsrk.SetValue(Constants.XenToolsUpdateSignalKey, "True");
+                    }
+                    else
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+            catch (Exception ex)
+            {
+                _logger.Log(ex.ToString());
+                return false;
+            }
+        }
+
+    }
+}

--- a/src/Rackspace.Cloud.Server.Agent/Commands/ResetNetwork.cs
+++ b/src/Rackspace.Cloud.Server.Agent/Commands/ResetNetwork.cs
@@ -61,10 +61,14 @@ namespace Rackspace.Cloud.Server.Agent.Commands
             var userMetadata = _xenUserMetadata.GetKeys();
             _setProviderData.Execute(providerData, userMetadata);
 
-            var hostname = _xenStore.ReadVmData("hostname");
-            var hostnameResult = _setHostname.SetHostname(hostname);
-
-            return new ExecutableResult() { ExitCode = hostnameResult };
+            if (string.IsNullOrEmpty(keyValue) || !keyValue.StartsWith("nohostname"))
+            {
+                var hostname = _xenStore.ReadVmData("hostname");
+                var hostnameResult = _setHostname.SetHostname(hostname);
+                return new ExecutableResult() { ExitCode = hostnameResult };
+            }
+            
+            return new ExecutableResult() { ExitCode = "0" };
         }
     }
 }

--- a/src/Rackspace.Cloud.Server.Agent/Constants.cs
+++ b/src/Rackspace.Cloud.Server.Agent/Constants.cs
@@ -26,6 +26,7 @@ namespace Rackspace.Cloud.Server.Agent {
         public const string RackspaceRegKey = @"SOFTWARE\Rackspace";
         public const string CloudAutomationSysPrepRegKey = "cloud-automation";
         public const string CloudAutomationKMSActivateRegKey = "cloud-automation-run";
+        public const string XenToolsUpdateSignalKey = "xentools-update-signal";
         
         public const string CloudAutomationCmdPath = @"c:\cloud-automation\bootstrap.cmd";
         public const string CloudAutomationBatPath = @"c:\cloud-automation\bootstrap.bat";
@@ -62,6 +63,7 @@ namespace Rackspace.Cloud.Server.Agent {
         public static readonly string XenToolsReleasePackage = SvcConfiguration.AgentVersionUpdatesPath + "xensetup.exe.zip";
         public static readonly string XenToolsUnzipPath = SvcConfiguration.AgentVersionUpdatesPath + "xentools";
         public static readonly string XenToolsSetupExecutablePath = XenToolsUnzipPath + @"\xensetup.exe";
+        public static readonly string XenToolsSetupScriptPath = XenToolsUnzipPath + @"\install.bat";
 
         public static readonly string UpdaterUnzipPath = SvcConfiguration.AgentVersionUpdatesPath + "updater";
         public static readonly string UpdaterBackupPath = SvcConfiguration.AgentVersionUpdatesPath + "current_updater";

--- a/src/Rackspace.Cloud.Server.Agent/IoC.cs
+++ b/src/Rackspace.Cloud.Server.Agent/IoC.cs
@@ -84,6 +84,8 @@ namespace Rackspace.Cloud.Server.Agent {
             StructureMapConfiguration.BuildInstancesOf<IExtractEmbededResource>().TheDefaultIsConcreteType<ExtractEmbededResource>();
             StructureMapConfiguration.BuildInstancesOf<ICloudAutomationSubActions>().TheDefaultIsConcreteType<CloudAutomationSubActions>();
             StructureMapConfiguration.BuildInstancesOf<ICloudAutomationActions>().TheDefaultIsConcreteType<CloudAutomationActions>();
+            StructureMapConfiguration.BuildInstancesOf<IXenToolsUpdateActions>().TheDefaultIsConcreteType<XenToolsUpdateActions>();
+            StructureMapConfiguration.BuildInstancesOf<IXenToolsUpdateSubActions>().TheDefaultIsConcreteType<XenToolsUpdateSubActions>();
 
 
             StructureMapConfiguration.BuildInstancesOf<IDiffieHellman>().TheDefaultIs(

--- a/src/Rackspace.Cloud.Server.Agent/Properties/AssemblyInfo.cs
+++ b/src/Rackspace.Cloud.Server.Agent/Properties/AssemblyInfo.cs
@@ -4,5 +4,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCompany("Rackspace Cloud")]
 [assembly: AssemblyProduct("Rackspace Cloud Server Agent")]
 [assembly: AssemblyCopyright("Copyright (c) 2009 2010 2011, Rackspace Cloud.  All Rights Reserved")]
-[assembly: AssemblyVersion("1.3.0.3")]
+[assembly: AssemblyVersion("1.3.1.0")]
 

--- a/src/Rackspace.Cloud.Server.Agent/Rackspace.Cloud.Server.Agent.csproj
+++ b/src/Rackspace.Cloud.Server.Agent/Rackspace.Cloud.Server.Agent.csproj
@@ -104,6 +104,8 @@
     <Compile Include="Actions\Sleeper.cs" />
     <Compile Include="Actions\ServiceStarter.cs" />
     <Compile Include="Actions\ServiceStopper.cs" />
+    <Compile Include="Actions\XenToolsUpdateActions.cs" />
+    <Compile Include="Actions\XenToolsUpdateSubActions.cs" />
     <Compile Include="Commands\EnsureMinAgentUpdater.cs" />
     <Compile Include="Commands\SetHostname.cs" />
     <Compile Include="Commands\Unrescue.cs" />

--- a/src/Rackspace.Cloud.Server.Common/Properties/AssemblyInfo.cs
+++ b/src/Rackspace.Cloud.Server.Common/Properties/AssemblyInfo.cs
@@ -4,5 +4,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCompany("Rackspace Cloud")]
 [assembly: AssemblyProduct("Rackspace Cloud Server Agent")]
 [assembly: AssemblyCopyright("Copyright (c) 2009 2010 2011, Rackspace Cloud.  All Rights Reserved")]
-[assembly: AssemblyVersion("1.3.0.3")]
+[assembly: AssemblyVersion("1.3.1.0")]
 

--- a/src/Rackspace.Cloud.Server.DiffieHellman.Specs/Properties/AssemblyInfo.cs
+++ b/src/Rackspace.Cloud.Server.DiffieHellman.Specs/Properties/AssemblyInfo.cs
@@ -4,5 +4,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCompany("Rackspace Cloud")]
 [assembly: AssemblyProduct("Rackspace Cloud Server Agent")]
 [assembly: AssemblyCopyright("Copyright (c) 2009 2010 2011, Rackspace Cloud.  All Rights Reserved")]
-[assembly: AssemblyVersion("1.3.0.3")]
+[assembly: AssemblyVersion("1.3.1.0")]
 


### PR DESCRIPTION
- Added logic to run install.bat if it exists in a Xen Tools package for installs
- Added logic that runs reset-network after a Xen Tools install is executed with a custom install.bat file
- Added logic to read/write/remove a new registry key to trigger the reset-network after a custom package has rebooted the machine and Xen Tools WMI interface comes online.
 - This check only happens at service start.