### PR TITLE
Fixed rare bug with IPv6 cleanup logic for network reset

### DIFF
--- a/Properties.rb
+++ b/Properties.rb
@@ -6,7 +6,7 @@ COPYRIGHT = "Copyright (c) 2009 2010 2011, Rackspace Cloud.  All Rights Reserved
 COMPANY = "Rackspace Cloud"
 DESCRIPTION = "C#.NET Agent for Windows Virtual Machines"
 CLR_VERSION = 'v3.5'
-RELEASE_BUILD_NUMBER = "1.3.1.0"
+RELEASE_BUILD_NUMBER = "1.3.1.1"
 
 #Paths
 SLN_FILE = File.join(ABSOLUTE_PATH,'src','WindowsConfigurationAgent.sln')

--- a/src/Rackspace.Cloud.Server.Agent.DiffieHellman/Properties/AssemblyInfo.cs
+++ b/src/Rackspace.Cloud.Server.Agent.DiffieHellman/Properties/AssemblyInfo.cs
@@ -4,5 +4,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCompany("Rackspace Cloud")]
 [assembly: AssemblyProduct("Rackspace Cloud Server Agent")]
 [assembly: AssemblyCopyright("Copyright (c) 2009 2010 2011, Rackspace Cloud.  All Rights Reserved")]
-[assembly: AssemblyVersion("1.3.1.0")]
+[assembly: AssemblyVersion("1.3.1.1")]
 

--- a/src/Rackspace.Cloud.Server.Agent.Service/Properties/AssemblyInfo.cs
+++ b/src/Rackspace.Cloud.Server.Agent.Service/Properties/AssemblyInfo.cs
@@ -4,5 +4,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCompany("Rackspace Cloud")]
 [assembly: AssemblyProduct("Rackspace Cloud Server Agent")]
 [assembly: AssemblyCopyright("Copyright (c) 2009 2010 2011, Rackspace Cloud.  All Rights Reserved")]
-[assembly: AssemblyVersion("1.3.1.0")]
+[assembly: AssemblyVersion("1.3.1.1")]
 

--- a/src/Rackspace.Cloud.Server.Agent.Specs/Properties/AssemblyInfo.cs
+++ b/src/Rackspace.Cloud.Server.Agent.Specs/Properties/AssemblyInfo.cs
@@ -4,5 +4,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCompany("Rackspace Cloud")]
 [assembly: AssemblyProduct("Rackspace Cloud Server Agent")]
 [assembly: AssemblyCopyright("Copyright (c) 2009 2010 2011, Rackspace Cloud.  All Rights Reserved")]
-[assembly: AssemblyVersion("1.3.1.0")]
+[assembly: AssemblyVersion("1.3.1.1")]
 

--- a/src/Rackspace.Cloud.Server.Agent.Specs/SetNetworkInterfaceSpec.cs
+++ b/src/Rackspace.Cloud.Server.Agent.Specs/SetNetworkInterfaceSpec.cs
@@ -147,7 +147,7 @@ namespace Rackspace.Cloud.Server.Agent.Specs {
             ExecutableProcessQueue.AssertWasCalled(
                 x =>
                 x.Enqueue("netsh",
-                          "interface ipv6 delete address interface=\"Lan1\" address=2001:4801:787F:202:278E:89D8:FF06:B476"));
+                          "interface ipv6 delete address interface=\"Lan1\" address=2001:4801:787F:202:278E:89D8:FF06:B476", new[] { "0", "1" }));
 
 
             ExecutableProcessQueue.AssertWasCalled(

--- a/src/Rackspace.Cloud.Server.Agent.UpdaterService/Properties/AssemblyInfo.cs
+++ b/src/Rackspace.Cloud.Server.Agent.UpdaterService/Properties/AssemblyInfo.cs
@@ -4,5 +4,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCompany("Rackspace Cloud")]
 [assembly: AssemblyProduct("Rackspace Cloud Server Agent")]
 [assembly: AssemblyCopyright("Copyright (c) 2009 2010 2011, Rackspace Cloud.  All Rights Reserved")]
-[assembly: AssemblyVersion("1.3.1.0")]
+[assembly: AssemblyVersion("1.3.1.1")]
 

--- a/src/Rackspace.Cloud.Server.Agent/Actions/SetNetworkInterface.cs
+++ b/src/Rackspace.Cloud.Server.Agent/Actions/SetNetworkInterface.cs
@@ -200,11 +200,11 @@ namespace Rackspace.Cloud.Server.Agent.Actions
                 // - Adding an ipv6 interface address and removing it, if not the delete ipv6 address fails with "The system cannot find the file specified."
                 var addAddresscommand = string.Format("interface ipv6 add address interface=\"{0}\" address=1::",
                                             interfaceName);
-                _executableProcessQueue.Enqueue("netsh", addAddresscommand);
+                _executableProcessQueue.Enqueue("netsh", addAddresscommand, new[] { "0", "1" });
 
                 var deleteAddresscommand = string.Format("interface ipv6 delete address interface=\"{0}\" address=1::",
                                             interfaceName);
-                _executableProcessQueue.Enqueue("netsh", deleteAddresscommand);
+                _executableProcessQueue.Enqueue("netsh", deleteAddresscommand, new[] { "0", "1" });
 
                 #endregion
                 // Do the real thing :-)
@@ -212,7 +212,7 @@ namespace Rackspace.Cloud.Server.Agent.Actions
                 string address = ipv6Address.ToString().Split('%')[0].ToUpper();
                 var command = string.Format("interface ipv6 delete address interface=\"{0}\" address={1}",
                                             interfaceName, address);
-                _executableProcessQueue.Enqueue("netsh", command);
+                _executableProcessQueue.Enqueue("netsh", command, new[] { "0", "1" });
             }
             _executableProcessQueue.Enqueue("netsh",
                                             string.Format("interface ipv6 delete route ::/0 \"{0}\"", interfaceName),

--- a/src/Rackspace.Cloud.Server.Agent/Properties/AssemblyInfo.cs
+++ b/src/Rackspace.Cloud.Server.Agent/Properties/AssemblyInfo.cs
@@ -4,5 +4,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCompany("Rackspace Cloud")]
 [assembly: AssemblyProduct("Rackspace Cloud Server Agent")]
 [assembly: AssemblyCopyright("Copyright (c) 2009 2010 2011, Rackspace Cloud.  All Rights Reserved")]
-[assembly: AssemblyVersion("1.3.1.0")]
+[assembly: AssemblyVersion("1.3.1.1")]
 

--- a/src/Rackspace.Cloud.Server.Common/Properties/AssemblyInfo.cs
+++ b/src/Rackspace.Cloud.Server.Common/Properties/AssemblyInfo.cs
@@ -4,5 +4,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCompany("Rackspace Cloud")]
 [assembly: AssemblyProduct("Rackspace Cloud Server Agent")]
 [assembly: AssemblyCopyright("Copyright (c) 2009 2010 2011, Rackspace Cloud.  All Rights Reserved")]
-[assembly: AssemblyVersion("1.3.1.0")]
+[assembly: AssemblyVersion("1.3.1.1")]
 

--- a/src/Rackspace.Cloud.Server.DiffieHellman.Specs/Properties/AssemblyInfo.cs
+++ b/src/Rackspace.Cloud.Server.DiffieHellman.Specs/Properties/AssemblyInfo.cs
@@ -4,5 +4,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCompany("Rackspace Cloud")]
 [assembly: AssemblyProduct("Rackspace Cloud Server Agent")]
 [assembly: AssemblyCopyright("Copyright (c) 2009 2010 2011, Rackspace Cloud.  All Rights Reserved")]
-[assembly: AssemblyVersion("1.3.1.0")]
+[assembly: AssemblyVersion("1.3.1.1")]
 


### PR DESCRIPTION
- Fixed an issue where the cleanup procedure before reset-network would fail because ip v6 loopback address would have been configured on a different nic